### PR TITLE
Provide support for Django 1.4

### DIFF
--- a/lot/models.py
+++ b/lot/models.py
@@ -4,7 +4,12 @@ from django.db import models
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from django.contrib.auth import get_user_model
+try:
+    from django.contrib.auth import get_user_model
+except ImportError:
+    from django.contrib.auth.models import User
+    def get_user_model():
+        return User
 
 from django.utils.timezone import now
 


### PR DESCRIPTION
it's an LTS release, currently still supported, and doesn't implement [get_user_model](https://github.com/django/django/blob/151d6dbf9c04539bf557af7b380e2a941b7745e4/django/contrib/auth/__init__.py)